### PR TITLE
Add REDASH_HOSTS_AND_API_KEYS to use multiple Re:dash at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ $ node index.js
 You can easy to deploy redashbot to Heroku, just click following button.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
+## Environment variables
+
+### SLACK_BOT_TOKEN (required)
+
+Slack's Bot User Token
+
+### REDASH_HOST and REDASH_API_KEY (optional)
+
+Re:dash's URL and its API Key.
+
+### REDASH_HOSTS_AND_API_KEYS (optional)
+
+If you want to use multiple Re:dash at once, specify this variable like below
+
+```
+REDASH_HOSTS_AND_API_KEYS="http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
+```

--- a/app.json
+++ b/app.json
@@ -12,6 +12,9 @@
     },
     "SLACK_BOT_TOKEN": {
       "description": "Slack bot token, for more detail see https://api.slack.com/bot-users"
+    },
+    "REDASH_HOSTS_AND_API_KEYS": {
+      "description": "If you want to use multiple Re:dash at once, specify like http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
     }
   },
   "formation": {

--- a/index.js
+++ b/index.js
@@ -6,19 +6,30 @@ const tempfile = require("tempfile");
 const fs = require("fs");
 const request = require("request");
 
-const requiredEnvVars = [
-  "REDASH_HOST",
-  "REDASH_API_KEY",
-  "SLACK_BOT_TOKEN"
-];
-const startupCheckPassed = requiredEnvVars.every((key) => { return process.env[key]; });
-if (!startupCheckPassed) {
-  console.error(`Error: Specify ${requiredEnvVars.join(", ")} in environment values`);
+if (!process.env.SLACK_BOT_TOKEN) {
+  console.error(`Error: Specify SLACK_BOT_TOKEN in environment values`);
+  process.exit(1);
+}
+if (!((process.env.REDASH_HOST && process.env.REDASH_API_KEY) || (process.env.REDASH_HOSTS_AND_API_KEYS))) {
+  console.error("Error: Specify REDASH_HOST and REDASH_API_KEY in environment values");
+  console.error("Or you can set multiple Re:dash configs by specifying like below");
+  console.error("REDASH_HOSTS_AND_API_KEYS=\"http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2\"");
   process.exit(1);
 }
 
-const redashHost = process.env.REDASH_HOST;
-const redashApiKey = process.env.REDASH_API_KEY;
+const parseApiKeysPerHost = () => {
+  if (process.env.REDASH_HOST) {
+    return {[process.env.REDASH_HOST]: process.env.REDASH_API_KEY};
+  } else {
+    return process.env.REDASH_HOSTS_AND_API_KEYS.split(",").reduce((m, host_and_key) => {
+      const [host, key] = host_and_key.split(";");
+      m[host] = key;
+      return m;
+    }, {});
+  }
+};
+
+const redashApiKeysPerHost = parseApiKeysPerHost();
 const slackBotToken = process.env.SLACK_BOT_TOKEN;
 
 const controller = Botkit.slackbot({
@@ -29,59 +40,62 @@ const bot = controller.spawn({
   token: slackBotToken
 }).startRTM();
 
-controller.hears(`${redashHost}/queries/([0-9]+)#([0-9]+)`, ["direct_message", "direct_mention", "mention"], (bot, message) => {
-  const queryId = message.match[1];
-  const visualizationId =  message.match[2];
-  const queryUrl = `${redashHost}/queries/${queryId}#${visualizationId}`;
-  const embedUrl = `${redashHost}/embed/query/${queryId}/visualization/${visualizationId}?api_key=${redashApiKey}`;
+Object.keys(redashApiKeysPerHost).forEach((redashHost) => {
+  controller.hears(`${redashHost}/queries/([0-9]+)#([0-9]+)`, ["direct_message", "direct_mention", "mention"], (bot, message) => {
+    const redashApiKey = redashApiKeysPerHost[redashHost];
+    const queryId = message.match[1];
+    const visualizationId =  message.match[2];
+    const queryUrl = `${redashHost}/queries/${queryId}#${visualizationId}`;
+    const embedUrl = `${redashHost}/embed/query/${queryId}/visualization/${visualizationId}?api_key=${redashApiKey}`;
 
-  bot.reply(message, `Taking screenshot of ${queryUrl}`);
-  bot.botkit.log(queryUrl);
-  bot.botkit.log(embedUrl);
+    bot.reply(message, `Taking screenshot of ${queryUrl}`);
+    bot.botkit.log(queryUrl);
+    bot.botkit.log(embedUrl);
 
-  const outputFile = tempfile(".png");
-  const webshotOptions = {
-    screenSize: {
-      width: 720,
-      height: 360
-    },
-    shotSize: {
-      width: 720,
-      height: "all"
-    }
-  };
-
-  webshot(embedUrl, outputFile, webshotOptions, (err) => {
-    if (err) {
-      const msg = `Something wrong happend in take a screen capture : ${err}`;
-      bot.reply(message, msg);
-      return bot.botkit.log.error(msg);
-    }
-
-    bot.botkit.log(outputFile);
-    bot.botkit.log(Object.keys(message));
-    bot.botkit.log(message.user + ":" + message.type + ":" + message.channel + ":" + message.text);
-
-    const options = {
-      token: slackBotToken,
-      filename: `query-${queryId}-visualization-${visualizationId}.png`,
-      file: fs.createReadStream(outputFile),
-      channels: message.channel
+    const outputFile = tempfile(".png");
+    const webshotOptions = {
+      screenSize: {
+        width: 720,
+        height: 360
+      },
+      shotSize: {
+        width: 720,
+        height: "all"
+      }
     };
 
-    // bot.api.file.upload cannot upload binary file correctly, so directly call Slack API.
-    request.post({ url: "https://api.slack.com/api/files.upload", formData: options }, (err, resp, body) => {
+    webshot(embedUrl, outputFile, webshotOptions, (err) => {
       if (err) {
-        const msg = `Something wrong happend in file upload : ${err}`;
+        const msg = `Something wrong happend in take a screen capture : ${err}`;
         bot.reply(message, msg);
-        bot.botkit.log.error(msg);
-      } else if (resp.statusCode == 200) {
-        bot.botkit.log("ok");
-      } else {
-        const msg = `Something wrong happend in file upload : status code=${resp.statusCode}`;
-        bot.reply(message, msg);
-        bot.botkit.log.error(msg);
+        return bot.botkit.log.error(msg);
       }
+
+      bot.botkit.log(outputFile);
+      bot.botkit.log(Object.keys(message));
+      bot.botkit.log(message.user + ":" + message.type + ":" + message.channel + ":" + message.text);
+
+      const options = {
+        token: slackBotToken,
+        filename: `query-${queryId}-visualization-${visualizationId}.png`,
+        file: fs.createReadStream(outputFile),
+        channels: message.channel
+      };
+
+      // bot.api.file.upload cannot upload binary file correctly, so directly call Slack API.
+      request.post({ url: "https://api.slack.com/api/files.upload", formData: options }, (err, resp, body) => {
+        if (err) {
+          const msg = `Something wrong happend in file upload : ${err}`;
+          bot.reply(message, msg);
+          bot.botkit.log.error(msg);
+        } else if (resp.statusCode == 200) {
+          bot.botkit.log("ok");
+        } else {
+          const msg = `Something wrong happend in file upload : status code=${resp.statusCode}`;
+          bot.reply(message, msg);
+          bot.botkit.log.error(msg);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
This is to allow multiple Re:dash configs.

If you want to use multiple Re:dash at once, specify `REDASH_HOSTS_AND_API_KEYS` like below.

```
REDASH_HOSTS_AND_API_KEYS="http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
```

`REDASH_HOST` and `REDASH_API_KEY` are still available.
