### PR TITLE
Make message events configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ If you want to use multiple Re:dash at once, specify this variable like below
 ```
 REDASH_HOSTS_AND_API_KEYS="http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
 ```
+
+### SLACK_MESSAGE_EVENTS (optional)
+
+Message events this bot reacts.
+Available values are listd in https://github.com/howdyai/botkit/blob/master/readme-slack.md#message-received-events
+Its default is *direct_message,direct_mention,mention*
+

--- a/app.json
+++ b/app.json
@@ -19,6 +19,10 @@
     "REDASH_HOSTS_AND_API_KEYS": {
       "description": "If you want to use multiple Re:dash at once, specify like http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2",
       "required": false
+    },
+    "SLACK_MESSAGE_EVENTS": {
+      "description": "Message events this bot reacts. Default is \"direct_message,direct_mention,mention\"Available values are listed in https://github.com/howdyai/botkit/blob/master/readme-slack.md#message-received-events",
+      "required": false
     }
   },
   "formation": {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const tempfile = require("tempfile");
 const fs = require("fs");
 const request = require("request");
 
+// This configuration can gets overwritten when process.env.SLACK_MESSAGE_EVENTS is given.
+const DEFAULT_SLACK_MESSAGE_EVENTS = "direct_message,direct_mention,mention";
+
 if (!process.env.SLACK_BOT_TOKEN) {
   console.error(`Error: Specify SLACK_BOT_TOKEN in environment values`);
   process.exit(1);
@@ -31,6 +34,7 @@ const parseApiKeysPerHost = () => {
 
 const redashApiKeysPerHost = parseApiKeysPerHost();
 const slackBotToken = process.env.SLACK_BOT_TOKEN;
+const slackMessageEvents = process.env.SLACK_MESSAGE_EVENTS || DEFAULT_SLACK_MESSAGE_EVENTS;
 
 const controller = Botkit.slackbot({
   debug: !!process.env.DEBUG
@@ -41,7 +45,7 @@ const bot = controller.spawn({
 }).startRTM();
 
 Object.keys(redashApiKeysPerHost).forEach((redashHost) => {
-  controller.hears(`${redashHost}/queries/([0-9]+)#([0-9]+)`, ["direct_message", "direct_mention", "mention"], (bot, message) => {
+  controller.hears(`${redashHost}/queries/([0-9]+)#([0-9]+)`, slackMessageEvents, (bot, message) => {
     const redashApiKey = redashApiKeysPerHost[redashHost];
     const queryId = message.match[1];
     const visualizationId =  message.match[2];


### PR DESCRIPTION
Add `DEFAULT_SLACK_MESSAGE_EVENTS` environment variable to replace the default message event types of _direct_message,direct_mention,mention_
