### PR TITLE
REDASH_HOST_ALIAS for bot to capable to reach Re:dash with alias URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,21 @@ Slack's Bot User Token
 
 Re:dash's URL and its API Key.
 
+## REDASH_HOST_ALIAS (optional)
+Re:dash' URL accessible from the bot.
+
 ### REDASH_HOSTS_AND_API_KEYS (optional)
 
 If you want to use multiple Re:dash at once, specify this variable like below
 
 ```
 REDASH_HOSTS_AND_API_KEYS="http://redash1.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
+```
+
+or if you need to specify REDASH_HOST_ALIAS for each Re:dash, like below
+
+```
+REDASH_HOSTS_AND_API_KEYS="http://redash1.example.com;http://redash1-alias.example.com;TOKEN1,http://redash2.example.com;TOKEN2"
 ```
 
 ### SLACK_MESSAGE_EVENTS (optional)

--- a/app.json
+++ b/app.json
@@ -12,6 +12,10 @@
       "description": "URL of your re:dash server, like https://your-redash-server.example.com",
       "required": false
     },
+    "REDASH_HOST_ALIAS": {
+      "description": "URL of your re:dash server accessible from the bot.",
+      "required": false
+    },
     "REDASH_API_KEY": {
       "description": "API key of your re:dash account",
       "required": false


### PR DESCRIPTION
I've added `REDASH_HOST_ALIAS` environment variable for the bot to capable to access the Re:dash server with an alias URL.
This feature needs when the URLs of the Re:dash servers for the users and ones for the bot are different because the networks they belong to are different.

For example, when the URL for the users is http://redash1.example.com and one for the bot is http://redash1.internal.example.com, we can set like below

```
REDASH_HOST=http://redash1.example.com
REDASH_HOST_ALIAS=http://redash1.internal.example.com
```

If we have many Re:dash servers and each severs has its alias name, we can set like below

```
REDASH_HOSTS_AND_API_KEYS=http://redash1.example.com;http://redash1.internal.example.com;xxxxx,REDASH_HOST;REDASH_HOST_ALIAS;REDASH_API_KEY,...
```

The middle value, _REDASH_HOST_ALIAS_, is optional so that this PR doesn't break the compatibility.

(I know we should set up a proper internal DNS server in such a case but this feature gives us another choice)
