### PR TITLE
Add node_modules to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git/
+node_modules


### PR DESCRIPTION
This PR prevents architecture dependent binaries from entering the docker image. (e.g. phantomjs-prebuild)