### PR TITLE
Add renderDelay option to support re:dash 1.0+

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ Object.keys(redashApiKeysPerHost).forEach((redashHost) => {
       shotSize: {
         width: 720,
         height: "all"
-      }
+      },
+      renderDelay: 1000,
+      timeout: 100000
     };
 
     webshot(embedUrl, outputFile, webshotOptions, (err) => {

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ Object.keys(redashApiKeysPerHost).forEach((redashHost) => {
         width: 720,
         height: "all"
       },
-      renderDelay: 1000,
+      renderDelay: 2000,
       timeout: 100000
     };
 


### PR DESCRIPTION
For #9 , it seems we have to wait before taking screen shot re:dash 1.0+